### PR TITLE
Stop CircleCI from sending failed checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+---
+
+###
+### This CircleCI configuration simply returns true.  It
+### checks nothing, builds nothing, displays nothing.
+### It simply returns true.  In all cases.  This is to
+### prevent erroneous failing checks from being passed
+### back to GitHub's Status Checks API due to a missing
+### CircleCI configuration.
+###
+
+version: 2.1
+jobs:
+  return-true:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: "return true"
+          command: "true"
+workflows:
+  say-hello-workflow:
+    jobs:
+      - return-true


### PR DESCRIPTION
CircleCI is pulling down our repo -- and we don't know why or who set this up -- and trying to run builds.  Cool.  However, there was no CircleCI configuration file so CircleCI would send a failing check back to GitHub's Status Checks API which would make GitHub think there was a problem.  This configuration file returns `true` in all cases, thereby inhibiting the failing checks from being passed back to GitHub.